### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/get_data/archive_india_gov/extract_indian_gov.py
+++ b/get_data/archive_india_gov/extract_indian_gov.py
@@ -10,7 +10,7 @@ from glob import glob
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: %s <dir>" % (__file__))
+        print("Usage: {0!s} <dir>".format((__file__)))
         sys.exit()
 
     data = dict()
@@ -46,7 +46,7 @@ if __name__ == "__main__":
                 #print(td.text)
         # Bio
         try:
-            with open(sys.argv[1] + "/bio-%s.html" % mpcode, encoding='utf-8') as m:
+            with open(sys.argv[1] + "/bio-{0!s}.html".format(mpcode), encoding='utf-8') as m:
                 html = m.read()
         except:
             html = ""
@@ -64,11 +64,11 @@ if __name__ == "__main__":
             elif tds[0].has_attr('align'):
                 rowspan = True
                 # For Loksabha 2015: data[mpcode][cur_key] += "\n%s|%s" % (tds[0].texti, tds[1].text.strip())
-                data[mpcode][cur_key] += "\n%s|%s" % (tds[0].texti.strip(), tds[1].text.strip())
+                data[mpcode][cur_key] += "\n{0!s}|{1!s}".format(tds[0].texti.strip(), tds[1].text.strip())
             if not rowspan:
                 data[mpcode][cur_key] = tds[1].text.strip()
 
-    o = open("%s-out.csv" % sys.argv[1].strip('/'), "wt", encoding='utf-8', newline='')
+    o = open("{0!s}-out.csv".format(sys.argv[1].strip('/')), "wt", encoding='utf-8', newline='')
     writer = csv.DictWriter(o, fieldnames=sorted(list(keys)), dialect='excel')
     writer.writeheader()
     for d in data:

--- a/get_data/archive_india_gov/scrape_indian_gov.py
+++ b/get_data/archive_india_gov/scrape_indian_gov.py
@@ -15,11 +15,11 @@ BASE_URL = 'http://www.archive.india.gov.in/govt/'
 if __name__ == "__main__":
     scraper = SimpleScraper()
     for h in HOUSE:
-        print("House type: %s" % h)
-        if not os.path.exists('./%s' % h):
-            os.mkdir('./%s' % h)
+        print("House type: {0!s}".format(h))
+        if not os.path.exists('./{0!s}'.format(h)):
+            os.mkdir('./{0!s}'.format(h))
 
-        html = scraper.get(BASE_URL + '%s.php?alpha=all' % h)
+        html = scraper.get(BASE_URL + '{0!s}.php?alpha=all'.format(h))
 
         soup = BeautifulSoup(html)
         i = 0
@@ -32,11 +32,11 @@ if __name__ == "__main__":
                 print(i, link)
                 html2 = scraper.get(BASE_URL + link)
                 if html2:
-                    with open('%s/detail-%s.html' % (h, mpcode), "wb") as f:
+                    with open('{0!s}/detail-{1!s}.html'.format(h, mpcode), "wb") as f:
                         f.write(str.encode(html2))
-                html3 = scraper.get(BASE_URL + '%smpbiodata.php?mpcode=%s' % (h, mpcode))
+                html3 = scraper.get(BASE_URL + '{0!s}mpbiodata.php?mpcode={1!s}'.format(h, mpcode))
                 if html3:
-                    with open('%s/bio-%s.html' % (h, mpcode), "wb") as f:
+                    with open('{0!s}/bio-{1!s}.html'.format(h, mpcode), "wb") as f:
                         f.write(str.encode(html3))
                 #break
-        print("Found: %d" % i)
+        print("Found: {0:d}".format(i))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:indian-politician-bios?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:indian-politician-bios?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
